### PR TITLE
 refact: use strings for notification messages instead of tables

### DIFF
--- a/lua/notifier.lua
+++ b/lua/notifier.lua
@@ -14,6 +14,10 @@ M.open = function(message, config)
   local title = utils.get_default(config.title, nil)
   local visible_time = utils.get_default(config.visible_time, 3000)
   local width = title and string.len(config.title) + 8 or 40
+
+  -- Split the notification message based on window width
+  message = utils.wrap_text(message, width - 4)
+
   local height = vim.tbl_count(message) + 2
   local top = '╭' .. string.rep('─', width - 2) .. '╮'
   local mid = '│' .. string.rep(' ', width - 2) .. '│'

--- a/lua/notifier.lua
+++ b/lua/notifier.lua
@@ -11,15 +11,15 @@ M.open = function(message, config)
   if not config then
     config = {}
   end
-  local title = utils.get_default(config.title, '')
+  local title = utils.get_default(config.title, nil)
   local visible_time = utils.get_default(config.visible_time, 3000)
-  local width = 40
+  local width = title and string.len(config.title) + 8 or 40
   local height = vim.tbl_count(message) + 2
   local top = '╭' .. string.rep('─', width - 2) .. '╮'
   local mid = '│' .. string.rep(' ', width - 2) .. '│'
   local bot = '╰' .. string.rep('─', width - 2) .. '╯'
-  if title ~= '' then
-    top = '╭' .. string.rep('─', width - (3 + string.len(config.title))) .. config.title .. '─╮'
+  if title then
+    top = '╭' .. string.rep('─', width - (8 + string.len(config.title))) .. '─ ' .. config.title .. ' ───╮'
     -- bot = '╰' .. string.rep('─', width - (3 + string.len(config.title))) .. config.title .. '─╯'
   end
 

--- a/lua/notifier/utils.lua
+++ b/lua/notifier/utils.lua
@@ -16,4 +16,47 @@ utils.runUserAutocmdLoaded = function()
   vim.cmd'do User NotifierNotificationLoaded'
 end
 
+-- split_into_tokens will wrap the provided string into tokens, that means
+-- every word will be a token.
+--
+-- @param str The string to be splitted
+-- @return table
+utils.split_into_tokens = function(str)
+  local tokens = {}
+  for word in str:gmatch('%S+') do
+    tokens[#tokens+1] = word
+  end
+
+  return tokens
+end
+
+-- wrap_text will wrap the provided string based on the provided length.
+--
+-- @param text The string to be wrapped
+-- @param line_length Where the string should break
+-- @return table
+utils.wrap_text = function(text, line_length)
+    if not line_length then
+        line_length = 80
+    end
+
+    local spaceleft = line_length
+    local wrapped_text = {}
+    local line = {}
+
+    for _, word in ipairs(utils.split_into_tokens(text)) do
+        if #word + 1 > spaceleft then
+            table.insert(wrapped_text, table.concat(line, ' '))
+            line = {word}
+            spaceleft = line_length - #word
+        else
+            table.insert(line, word)
+            spaceleft = spaceleft - (#word + 1)
+        end
+    end
+
+    table.insert(wrapped_text, table.concat(line, ' '))
+    return wrapped_text
+end
+
 return utils


### PR DESCRIPTION
Hey, it's me again. This PR gets rid of the current syntax for messages to use strings as they are better for the end user.

Internally everything works the same, with the exception that the string becomes a table when wrapping it based on the width of the notification.

> Known issues (needs to be fixed before merging this)

- If the notification message is longer than the terminal size the notification is incomplete. Maybe split the notification into various parts?